### PR TITLE
use dot for fqdn in edge vm

### DIFF
--- a/vghetto-vsphere-with-kubernetes-external-nsxt-lab-deployment.ps1
+++ b/vghetto-vsphere-with-kubernetes-external-nsxt-lab-deployment.ps1
@@ -710,7 +710,7 @@ if($deployNSXEdge -eq 1) {
     $NSXTEdgeHostnameToIPs.GetEnumerator() | Sort-Object -Property Value | Foreach-Object {
         $VMName = $_.Key
         $VMIPAddress = $_.Value
-        $VMHostname = "$VMName" + "@" + $VMDomain
+        $VMHostname = "$VMName" + "." + $VMDomain
 
         $nsxEdgeOvfConfig.DeploymentOption.Value = $NSXTEdgeDeploymentSize
         $nsxEdgeOvfConfig.NetworkMapping.Network_0.value = $VMNetwork


### PR DESCRIPTION
as today, edge name includes an @ 

so replacing with a dot, gets a proper fqdn, and with new changes, the script allows deploy more than 1 edge

thanks!