### PR TITLE
$VMVMFS is not used

### DIFF
--- a/vghetto-vsphere-with-kubernetes-external-nsxt-lab-deployment.ps1
+++ b/vghetto-vsphere-with-kubernetes-external-nsxt-lab-deployment.ps1
@@ -51,7 +51,6 @@ $VMSyslog = "172.17.31.112"
 $VMFolder = "Project-Pacific"
 # Applicable to Nested ESXi only
 $VMSSH = "true"
-$VMVMFS = "false"
 
 # Name of new vSphere Datacenter/Cluster when VCSA is deployed
 $NewVCDatacenterName = "Pacific-Datacenter"

--- a/vghetto-vsphere-with-kubernetes-external-nsxt-lab-deployment.ps1
+++ b/vghetto-vsphere-with-kubernetes-external-nsxt-lab-deployment.ps1
@@ -401,8 +401,6 @@ if($confirmDeployment -eq 1) {
     Write-Host -ForegroundColor White $VMSyslog
     Write-Host -NoNewline -ForegroundColor Green "Enable SSH: "
     Write-Host -ForegroundColor White $VMSSH
-    Write-Host -NoNewline -ForegroundColor Green "Create VMFS Volume: "
-    Write-Host -ForegroundColor White $VMVMFS
 
     Write-Host -ForegroundColor Yellow "`n---- VCSA Configuration ----"
     Write-Host -NoNewline -ForegroundColor Green "Deployment Size: "


### PR DESCRIPTION
$VMVMFS only gets used by a Write-Host command. It doesn't get used anywhere else for any kind of decision making. It should be removed.

I think the GitHub in-browser editor added a newline on the last line.